### PR TITLE
Revert

### DIFF
--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -141,7 +141,7 @@
   abstract: true
   components:
     - type: AlertLevel
-      alertLevelPrototype: taipanAlerts #ВРЕМЕННАЯ МЕРА НА СМЕНУ ТАЙПАНА!!!
+      alertLevelPrototype: stationAlerts
 
 - type: entity
   id: BaseStationExpeditions


### PR DESCRIPTION
Вернул стандартные уровни угроз. Также оставил сборку/разбор пластитановых стен потому что не вижу смысла их убирать. Остальные спрайты, синдифабы и т.д. оставлено, поскольку их всё-равно можно получить только щитспавном.  